### PR TITLE
Suggested improvement in handling key codes, replacing number with constants

### DIFF
--- a/Week-05/sketch_180614b/sketch_180614b.pde
+++ b/Week-05/sketch_180614b/sketch_180614b.pde
@@ -92,18 +92,22 @@ void createLetters(){
 
 void keyPressed(){
   
-  switch(keyCode){
-    case 39:
+switch(keyCode){
+    case RIGHT:
       gridSubdivisionsW ++;
+      createLetters();
       break;
-    case 37:
+    case LEFT:
       if(gridSubdivisionsW > 2) gridSubdivisionsW --;
+      createLetters();
       break;
-    case 38:
+    case UP:
       gridSubdivisionsH ++;
+      createLetters();
       break;
-    case 40:
+    case DOWN:
       if(gridSubdivisionsH > 2) gridSubdivisionsH --;
+      createLetters();
       break;
   }
   


### PR DESCRIPTION
A minor improvement to handling of arrow keys, which I feel is more intuitive to everyone, specially beginners. 

Instead of using 38,39,40,41 for keyboard arrows, you can use the constants RIGHT,LEFT,UP,DOWN. 
Another minor change is to include createLetters() under each `case`. This also makes handling the  `r` stroke redundant, but I did not change that. See addtiions below.